### PR TITLE
v1.9.1-fix1

### DIFF
--- a/NP_Views.php
+++ b/NP_Views.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
   History:
     v1.1
@@ -35,6 +35,10 @@
       - Added item title in admin menu
     v1.9.1
       - ignore draft in admin menu
+    v1.9.1-fix1
+      - short_open_tag off
+			- getURL method
+      - delete [$CONF['IndexURL'] . ] for views/index.php
 */
 class NP_Views extends NucleusPlugin {
 
@@ -53,10 +57,11 @@ class NP_Views extends NucleusPlugin {
       return 'Rodrigo Moraes | Edmond Hui (admun) | gRegor Morrill';
    }
    function getURL() {
-      return 'http://www.tipos.com.br';
+      // return 'http://www.tipos.com.br';
+      return 'https://github.com/NucleusCMS/NP_Views';
    }
    function getVersion() {
-      return '1.9.1';
+      return '1.9.1-fix1';
    }
    function getDescription() {
       return 'This plugin counts how many times an entry has been displayed.';
@@ -113,7 +118,7 @@ class NP_Views extends NucleusPlugin {
                  )
            );
    }
-   
+
    function doTemplateVar(&$item, $input) {
       $itemid = $item->itemid;
       $remote_ip = ServerVar('REMOTE_ADDR');
@@ -224,4 +229,3 @@ class NP_Views extends NucleusPlugin {
       header('Location: ' . $CONF['PluginURL'] . 'views/index.php?sort=' . $sort . '&order='.$order);
    }
 }
-?>

--- a/views/index.php
+++ b/views/index.php
@@ -2,12 +2,12 @@
 	// if your 'plugin' directory is not in the default location,
 	// edit this variable to point to your site directory
 	// (where config.php is)
-	$strRel = '../../../'; 
+	$strRel = '../../../';
 
 	include($strRel . 'config.php');
 	if (!$member->isLoggedIn())
 		doError('You\'re not logged in.');
-		
+
 	include($DIR_LIBS . 'PLUGINADMIN.php');
 
 	// create the admin area page
@@ -83,9 +83,9 @@
 
 	while($row = sql_fetch_object($rows)) {
 		$item = $manager->getItem($row->id, 0, 0);
-                $delurl = $CONF['ActionURL'] . '?action=plugin&name=Views&type=resetview&id=' . $row->id . "&order=" . $orderby . "&sort=" . $sortby; 
+                $delurl = $CONF['ActionURL'] . '?action=plugin&name=Views&type=resetview&id=' . $row->id . "&order=" . $orderby . "&sort=" . $sortby;
 		echo "<tr>";
-		echo "<td><a href=\"" . $CONF['IndexURL'] . createItemLink($row->id) . "\">" . $item['title'] . "</a></td>";
+		echo "<td><a href=\"" . createItemLink($row->id) . "\">" . $item['title'] . "</a></td>";
 		echo "<td>" . $row->views . "</td>";
 		echo "<td>" . "<a href=\"" . $delurl . "\">Reset count</a>" . "</td>";
 		echo "</tr>";
@@ -121,4 +121,3 @@
         echo $prelink . " | " . $nextlink . "<br/>";
 
 	$oPluginAdmin->end();
-?>


### PR DESCRIPTION
short_open_tag = offの環境ではインストールができなかったので<?phpとしました。
getURLメソッドの返り値のホストがもうないみたいなのでgithubに。
views/index.php 88行目$CONF['IndexURL'] . createItemLink($row->id)となっておりhttp://が2つ続くのでなおしました。